### PR TITLE
build: pin zmk 0.1 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,4 +2,4 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,4 +2,4 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.1
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3

--- a/config/west.yml
+++ b/config/west.yml
@@ -1,0 +1,11 @@
+manifest:
+  remotes:
+    - name: zmkfirmware
+      url-base: https://github.com/zmkfirmware
+  projects:
+    - name: zmk
+      remote: zmkfirmware
+      revision: v0.1
+      import: app/west.yml
+  self:
+    path: config

--- a/config/west.yml
+++ b/config/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: v0.1
+      revision: v0.3
       import: app/west.yml
   self:
     path: config


### PR DESCRIPTION
Замена плавающей версии zmk в main ветке на жесткую 0.1

Текущая ZMK использует версию Zephyr 4.1.0, не совместимую со старой структурой описания плат.